### PR TITLE
feat: add notification-to-toaster transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,30 @@ toaster.push(
 );
 ```
 
+#### `notification-to-toaster`
+
+Transform `Notification` calls to `toaster`
+
+https://rsuitejs.com/guide/v5-features/#refactor-notification
+
+```jsx
+// for rsuite v4
+Notification.info({
+  title: "info",
+  description: "description",
+  duration: 4500,
+  placement: "topStart",
+});
+
+// for rsuite v5
+toaster.push(
+  <Notification type="info" header="info" duration={4500} closable>
+    description
+  </Notification>,
+  { placement: "topStart" }
+);
+```
+
 #### `rename-form-components`
 
 https://next.rsuitejs.com/guide/v5-features/#2-6-rename-form-related-components

--- a/transforms/__testfixtures__/notification-to-toaster/existing-toaster.input.js
+++ b/transforms/__testfixtures__/notification-to-toaster/existing-toaster.input.js
@@ -1,0 +1,8 @@
+import { toaster, Notification } from "rsuite";
+
+Notification.info({
+  title: "info",
+  description: "description",
+  duration: 4500,
+  placement: "topStart",
+});

--- a/transforms/__testfixtures__/notification-to-toaster/existing-toaster.output.js
+++ b/transforms/__testfixtures__/notification-to-toaster/existing-toaster.output.js
@@ -1,0 +1,8 @@
+import { toaster, Notification } from "rsuite";
+
+toaster.push(
+  <Notification type="info" header="info" duration={4500} closable>description</Notification>,
+  {
+    placement: "topStart"
+  }
+);

--- a/transforms/__testfixtures__/notification-to-toaster/notification-description-expression.input.js
+++ b/transforms/__testfixtures__/notification-to-toaster/notification-description-expression.input.js
@@ -1,0 +1,12 @@
+import { Notification } from "rsuite";
+
+Notification.warning({
+  title: "服务维护中，请稍后再试",
+  description: `${thrown.response.status} ${thrown.response.statusText}`,
+  duration: 5000,
+});
+
+Notification.error({
+  title: `请求错误：${thrown.response.data.message ?? "未知错误"}`,
+  description: `${thrown.response.status} ${thrown.response.statusText}`,
+});

--- a/transforms/__testfixtures__/notification-to-toaster/notification-description-expression.output.js
+++ b/transforms/__testfixtures__/notification-to-toaster/notification-description-expression.output.js
@@ -1,0 +1,10 @@
+import { toaster, Notification } from "rsuite";
+
+toaster.push(
+  <Notification type="warning" header="服务维护中，请稍后再试" duration={5000} closable>{`${thrown.response.status} ${thrown.response.statusText}`}</Notification>
+);
+
+toaster.push(<Notification
+  type="error"
+  header={`请求错误：${thrown.response.data.message ?? "未知错误"}`}
+  closable>{`${thrown.response.status} ${thrown.response.statusText}`}</Notification>);

--- a/transforms/__testfixtures__/notification-to-toaster/notification-type.input.js
+++ b/transforms/__testfixtures__/notification-to-toaster/notification-type.input.js
@@ -1,0 +1,8 @@
+import { Notification } from "rsuite";
+
+Notification.info({
+  title: "info",
+  description: "description",
+  duration: 4500,
+  placement: "topStart",
+});

--- a/transforms/__testfixtures__/notification-to-toaster/notification-type.output.js
+++ b/transforms/__testfixtures__/notification-to-toaster/notification-type.output.js
@@ -1,0 +1,8 @@
+import { toaster, Notification } from "rsuite";
+
+toaster.push(
+  <Notification type="info" header="info" duration={4500} closable>description</Notification>,
+  {
+    placement: "topStart"
+  }
+);

--- a/transforms/__tests__/notification-to-toaster.test.js
+++ b/transforms/__tests__/notification-to-toaster.test.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const defineTest = require("jscodeshift/dist/testUtils").defineTest;
+
+defineTest(__dirname, "notification-to-toaster", null, "no-rsuite-import");
+defineTest(
+  __dirname,
+  "notification-to-toaster",
+  null,
+  "notification-to-toaster/notification-type"
+);
+defineTest(
+  __dirname,
+  "notification-to-toaster",
+  null,
+  "notification-to-toaster/notification-description-expression"
+);
+defineTest(
+  __dirname,
+  "notification-to-toaster",
+  null,
+  "notification-to-toaster/existing-toaster"
+);

--- a/transforms/notification-to-toaster.js
+++ b/transforms/notification-to-toaster.js
@@ -1,0 +1,168 @@
+/**
+ * Transform Notification calls to toaster
+ *
+ * // for rsuite v4
+ * Notification.info({
+ *   title: 'info',
+ *   description: 'description',
+ *   duration: 4500,
+ *   placement: 'topStart'
+ * });
+ *
+ * // for rsuite v5
+ * toaster.push(
+ *   <Notification type="info" header="info" duration={4500}>
+ *     description
+ *   </Notification>,
+ *   { placement: 'topStart' }
+ * );
+ */
+"use strict";
+
+/**
+ * @type {import('jscodeshift').Transform}
+ */
+module.exports = (file, api, options) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const rsuiteImport = root
+    .find(j.ImportDeclaration, {
+      source: {
+        type: "StringLiteral",
+        value: "rsuite",
+      },
+    })
+    .at(0);
+
+  rsuiteImport
+    .find(j.ImportSpecifier, {
+      imported: {
+        name: "Notification",
+      },
+    })
+    .forEach((notificationImport) => {
+      const importedNotification = notificationImport.value;
+
+      const notificationCalls = root.find(j.CallExpression, {
+        callee: {
+          object: {
+            name: importedNotification.local.name,
+          },
+        },
+      });
+
+      // replace import { Notification } with { toaster, Notification }
+
+      const toaster = j.identifier("toaster");
+      const Notification = j.jsxIdentifier("Notification");
+
+      if (
+        rsuiteImport
+          .find(j.ImportSpecifier, {
+            imported: {
+              name: "toaster",
+            },
+          })
+          .size() < 1
+      ) {
+        j(notificationImport).insertBefore(j.importSpecifier(toaster));
+      }
+
+      // replace
+      // Notification[type].({
+      //   title,
+      //   description,
+      //   duration,
+      //   placement
+      // })
+      // with
+      // toaster.push(
+      //   <Notification type={type} header={title} duration={duration} closable>
+      //     {description}
+      //   </Notification>,
+      //  { placement }
+      // )
+      notificationCalls.forEach((call) => {
+        const notificationType = call.value.callee.property.name;
+
+        const notificationTitle = call.value.arguments[0].properties.find(
+          (p) => p.key.name === "title"
+        );
+        const notificationDescription = call.value.arguments[0].properties.find(
+          (p) => p.key.name === "description"
+        );
+        const notificationDuration = call.value.arguments[0].properties.find(
+          (p) => p.key.name === "duration"
+        );
+
+        const notificationPlacement = call.value.arguments[0].properties.find(
+          (p) => p.key.name === "placement"
+        );
+
+        const notificationAttributes = [
+          j.jsxAttribute(
+            j.jsxIdentifier("type"),
+            j.stringLiteral(notificationType)
+          ),
+        ];
+
+        if (notificationTitle) {
+          notificationAttributes.push(
+            j.jsxAttribute(
+              j.jsxIdentifier("header"),
+              j.StringLiteral.check(notificationTitle.value)
+                ? notificationTitle.value
+                : j.jsxExpressionContainer(notificationTitle.value)
+            )
+          );
+        }
+
+        if (notificationDuration) {
+          notificationAttributes.push(
+            j.jsxAttribute(
+              j.jsxIdentifier("duration"),
+              j.jsxExpressionContainer(notificationDuration.value)
+            )
+          );
+        }
+
+        notificationAttributes.push(
+          j.jsxAttribute(j.jsxIdentifier("closable"))
+        );
+
+        const toasterCallArguments = [
+          j.jsxElement(
+            j.jsxOpeningElement(Notification, notificationAttributes),
+            j.jsxClosingElement(Notification),
+            [
+              j.StringLiteral.check(notificationDescription.value)
+                ? j.jsxText(notificationDescription.value.value)
+                : j.jsxExpressionContainer(notificationDescription.value),
+            ]
+          ),
+        ];
+
+        if (notificationPlacement) {
+          toasterCallArguments.push(
+            j.objectExpression([
+              j.objectProperty(
+                j.identifier("placement"),
+                notificationPlacement.value
+              ),
+            ])
+          );
+        }
+
+        j(call).replaceWith(
+          j.callExpression(
+            j.memberExpression(toaster, j.identifier("push")),
+            toasterCallArguments
+          )
+        );
+      });
+    });
+  return root.toSource();
+};
+
+module.exports.parser = "tsx";


### PR DESCRIPTION
Transform `Notification` calls to `toaster` API.
https://rsuitejs.com/guide/v5-features/#refactor-notification

```jsx
// for rsuite v4
Notification.info({
  title: 'info',
  description: 'description',
  duration: 4500,
  placement: 'topStart'
});

// for rsuite v5
toaster.push(
  <Notification type="info" header="info" duration={4500} closable>
    description
  </Notification>,
  { placement: 'topStart' }
);
```